### PR TITLE
useDarkMode 훅 작성 / atom effect를 이용한 로컬스토리지에 theme 저장(for persisting t…

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,7 +1,7 @@
 import { themeAtom } from '@src/recoil/atom/theme';
 import { useRecoilState } from 'recoil';
 import { useCallback, useEffect } from 'react';
-const useDarkMdoe = () => {
+const useDarkMode = () => {
   const [theme, setTheme] = useRecoilState(themeAtom);
   const toggleTheme = useCallback(() => {
     // atom effect로 set이 실행되면 localStorage 갱신
@@ -16,4 +16,4 @@ const useDarkMdoe = () => {
   }, [setTheme, theme]);
   return { theme, toggleTheme };
 };
-export default useDarkMdoe;
+export default useDarkMode;

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,19 @@
+import { themeAtom } from '@src/recoil/atom/theme';
+import { useRecoilState } from 'recoil';
+import { useCallback, useEffect } from 'react';
+const useDarkMdoe = () => {
+  const [theme, setTheme] = useRecoilState(themeAtom);
+  const toggleTheme = useCallback(() => {
+    // atom effect로 set이 실행되면 localStorage 갱신
+    theme === 'light' ? setTheme('dark') : setTheme('light');
+  }, [setTheme, theme]);
+
+  useEffect(() => {
+    if (!localStorage.getItem('theme')) {
+      // default 로 설정된 atom value 사용 (light)
+      setTheme(theme);
+    }
+  }, [setTheme, theme]);
+  return { theme, toggleTheme };
+};
+export default useDarkMdoe;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,17 +8,20 @@ import LoginModal from '@src/components/Organisms/LoginModal';
 import RegisterModal from '@src/components/Organisms/RegisterModal';
 import DIText from '@src/components/Atoms/DIText';
 import styled from 'styled-components';
+import useDarkMdoe from '@src/hooks/useDarkMode';
 const Home = () => {
   const { user, loading } = useAuthentication();
   const history = useHistory();
   const [modal, setModal] = useRecoilState(modalAtom);
+  const { theme, toggleTheme } = useDarkMdoe();
 
   useEffect(() => {
     // when user joined first.
+    console.log(theme); // check theme
     if (user && !user.isEnrolled) {
       setModal({ id: 'register', visible: true });
     }
-  }, [user, history, setModal]);
+  }, [user, history, setModal, theme]);
 
   const onClickLogin = useCallback(() => {
     setModal({ id: 'login', visible: true });
@@ -29,12 +32,14 @@ const Home = () => {
   }, [setModal]);
 
   return (
+    // <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme }> 이런 식?..
     <Container>
       {loading === true ? (
         <EmptyScreen />
       ) : (
         <Header>
           <DIText>Home</DIText>
+          <button onClick={toggleTheme}>Toggle Theme</button>
           <Wrapper>
             <DIText>안녕하세요 {user?.nickname ?? 'Stranger'}</DIText>
             {user === null && <button onClick={onClickLogin}>Login</button>}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,12 +8,12 @@ import LoginModal from '@src/components/Organisms/LoginModal';
 import RegisterModal from '@src/components/Organisms/RegisterModal';
 import DIText from '@src/components/Atoms/DIText';
 import styled from 'styled-components';
-import useDarkMdoe from '@src/hooks/useDarkMode';
+import useDarkMode from '@src/hooks/useDarkMode';
 const Home = () => {
   const { user, loading } = useAuthentication();
   const history = useHistory();
   const [modal, setModal] = useRecoilState(modalAtom);
-  const { theme, toggleTheme } = useDarkMdoe();
+  const { theme, toggleTheme } = useDarkMode();
 
   useEffect(() => {
     // when user joined first.

--- a/src/recoil/atom/theme.ts
+++ b/src/recoil/atom/theme.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+
+export const themeAtom = atom({
+  key: 'theme',
+  default: 'light',
+  effects_UNSTABLE: [
+    ({ setSelf, onSet }) => {
+      const storedTheme = localStorage.getItem('theme');
+      // 이미 localStorage에 저장된 theme이 있다면 setSelf
+      if (storedTheme != null) {
+        setSelf(storedTheme);
+      }
+      // 처리 방식 모르겠음 any로 안하면 type err
+      onSet((theme: any) => {
+        localStorage.setItem('theme', JSON.stringify(theme));
+      });
+    },
+  ],
+});


### PR DESCRIPTION
styled-components의 ThemeProvider를 이용할 듯 싶어서 theme 변환을 위해 `useDarkMode` 훅을 작성했습니다.

- theme 상태를 관리할 수 있는 atom 정의 `recoil/atom/theme.ts` ('light' || 'dark')
- atom effect를 통해 theme이 set 되었을 때(onSet) 로컬스토리지도 즉각적으로 변환될 수 있도록 했습니다.
- 웹사이트가 열리고 로컬스토리지에 theme 데이터가 있을 경우 `setSelf(storedTheme)` 을 통해 themeAtom을 업데이트 합니다.
- 로컬스토리지에 없을 경우 themeAtom의 default value('light')로 설정 및 로컬스토리지에 저장합니다.
- `useDarkMode` 훅은 { theme, toggleTheme } 을 리턴합니다.

마지막으로 설정한 theme을 유저가  다시 방문했을 때 유지하기 위해 로컬 스토리지를 이용해봤습니다.
