### PR TITLE
BUG: header navigation url 변경 시 유지되도록 변경 & 모달이 창 크기에 맞게 centering 되도록 수정

### DIFF
--- a/src/components/Organisms/Modal/styles.tsx
+++ b/src/components/Organisms/Modal/styles.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import CloseButton from '@src/assets/close_button.svg';
 export const CreateModal = styled.div`
+  display: flex;
+  align-items: center;
   position: fixed;
   text-align: center;
   left: 0;
@@ -13,8 +15,7 @@ export const CreateModal = styled.div`
 
   & > div {
     opacity: 1 !important;
-    margin-top: 200px;
-    display: inline-block;
+    margin: 0 auto;
     width: 494px;
     height: 539px;
     background: white;

--- a/src/layouts/App/index.tsx
+++ b/src/layouts/App/index.tsx
@@ -17,7 +17,7 @@ const App = () => {
 
   return (
     <ThemeProvider theme={theme === 'light' ? light : dark}>
-      <Route exact path="/" component={HeaderNavigation} />
+      <HeaderNavigation />
       <Switch>
         <Route exact path="/" component={Home} />
       </Switch>


### PR DESCRIPTION
- 기존 헤더 네비게이션이 라우트가 변경될 때마다 없어졌었는데 이를 수정 했습니다.
- 기존 모달이 웹의 창이 작아질 때 위아래로 centering 되지 않았는데, 이를 수정했습니다.