### PR TITLE
FEATURE: 닉네임 중복 체크

### DIFF
--- a/src/components/Organisms/Modal/RegisterModal.tsx
+++ b/src/components/Organisms/Modal/RegisterModal.tsx
@@ -2,7 +2,7 @@ import DIButton from '@src/components/Atoms/DIButton';
 import DIText from '@src/components/Atoms/DIText';
 import UserProfile from '@src/components/Molecules/UserProfile';
 import CloseIcon from '@src/assets/close_button.svg';
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import styled, { useTheme } from 'styled-components';
 import DIInput from '../../Atoms/DIInput';
@@ -12,12 +12,12 @@ import { RiErrorWarningLine } from 'react-icons/ri';
 import SelectInput from '../SelectInput';
 import { MdEdit } from 'react-icons/md';
 import CheckIcon from '@src/assets/check.svg';
-import { updateUserInfo } from '@src/service/api';
+import { checkNickname, updateUserInfo } from '@src/service/api';
 import ModalContainer from '@src/components/Molecules/ModalContainer';
 import { Tech } from '@src/typings/Tech';
 import { fileAtom } from '@src/recoil/atom/file';
 import { useUser } from '@src/hooks/useAuthentication';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 type RegisterModalProps = {
   onFinish: () => void;
@@ -41,7 +41,10 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
 
   // const [image, setImage] = useState<string>();
   const hiddenFileInput = useRef<HTMLInputElement>(null);
-  const [checkName, setCheckName] = useState<boolean>(false);
+  const { data: check } = useQuery('nicknameCheck', () => checkNickname(nickname), {
+    enabled: user && nickname.trim().length && page === 0 ? true : false,
+    refetchInterval: 100,
+  });
 
   const onUpload = useCallback(() => {
     if (hiddenFileInput.current) {
@@ -86,11 +89,6 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
       },
     },
   );
-  useEffect(() => {
-    if (true) {
-      setCheckName(true);
-    }
-  }, []);
 
   const NickNameContent = useCallback(() => {
     return (
@@ -113,7 +111,7 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
               placholder={'최대 8글자'}
             />
           </InputPlace>
-          {checkName ? (
+          {check ? (
             <DIText fontColor={theme.colors.main}>
               <AiOutlineCheck />
               사용가능한 닉네임입니다.
@@ -127,7 +125,7 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
         </CardContent>
         <CardBottom>
           <DIButton
-            disabled={nickname === null || nickname.trim().length === 0}
+            disabled={!check || nickname.trim().length === 0}
             value={'다음'}
             onClick={() => {
               onChangePage(1);
@@ -136,7 +134,7 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
         </CardBottom>
       </CardStyle>
     );
-  }, [checkName, nickname, onChangeName, onChangePage, theme]);
+  }, [nickname, onChangeName, onChangePage, theme, check]);
 
   const TechContent = useCallback(() => {
     return (

--- a/src/components/Organisms/Modal/RegisterModal.tsx
+++ b/src/components/Organisms/Modal/RegisterModal.tsx
@@ -18,6 +18,7 @@ import { Tech } from '@src/typings/Tech';
 import { fileAtom } from '@src/recoil/atom/file';
 import { useUser } from '@src/hooks/useAuthentication';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useDebounce } from '@src/hooks/useDebounce';
 
 type RegisterModalProps = {
   onFinish: () => void;
@@ -38,12 +39,10 @@ const RegisterModal = ({ onFinish, onClose, stopPropagation, width, height }: Re
   const [nickname, setNickname] = useState('');
   const [interestTechSet, setInterestTechSet] = useState<Tech[]>([]);
   const [file, setFile] = useRecoilState(fileAtom);
-
-  // const [image, setImage] = useState<string>();
+  const debounceInput = useDebounce(nickname, 200);
   const hiddenFileInput = useRef<HTMLInputElement>(null);
-  const { data: check } = useQuery('nicknameCheck', () => checkNickname(nickname), {
+  const { data: check } = useQuery(['nicknameCheck', debounceInput], () => checkNickname(debounceInput as string), {
     enabled: user && nickname.trim().length && page === 0 ? true : false,
-    refetchInterval: 100,
   });
 
   const onUpload = useCallback(() => {

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -56,6 +56,11 @@ const logoutUser = async () => {
   return code;
 };
 
+const checkNickname = async (nickname: string) => {
+  const { data } = await requestAPI().get(`/members/check?nickname=${nickname}`);
+  return data;
+};
+
 const getTodo = async () => {
   const { data } = await requestAPI().get('/todos/main');
   return data;
@@ -94,6 +99,7 @@ export {
   updateUserInfo,
   resignUser,
   logoutUser,
+  checkNickname,
   addTodo,
   getTodo,
   getTodoData,


### PR DESCRIPTION
닉네임 중복 체크를 구현했습니다.
중복 확인 버튼이 별도로 존재하는게 아니라 그냥 100ms 주기로 refetch 하면서 중복 체크 했습니다. 
`{ data: check }`
react-query `enable` 조건
1. 공백을 제외하고 문자열이 입력되어있을 때(nickname 상태값), 유저가 존재할 때
2. 회원가입 모달 내의 페이지가 0일 때 (닉네임을 입력하는 곳)

`check`값이 true일 때 button enable 되게끔 변경했습니다