### PR TITLE
feat: 인기태그 api 연동 (merge목적이아닌 review목적)

### DIFF
--- a/src/components/Molecules/Board/Tags.tsx
+++ b/src/components/Molecules/Board/Tags.tsx
@@ -1,7 +1,10 @@
 import LottieLoading from '@src/components/Atoms/LottieLoading';
 import useTag from '@src/hooks/useTag';
+import tag from '@src/service/tag';
+import { Tag } from '@src/typings/Board';
 import { devices } from '@src/utils/theme';
 import React from 'react';
+import { useQuery } from 'react-query';
 import styled from 'styled-components';
 
 type Props = {
@@ -10,16 +13,28 @@ type Props = {
 };
 
 const Tags = ({ onChangeCategory, category }: Props) => {
-  const { useLimitPopularTag, usePopularTag } = useTag();
-  // const { data: tags, isLoading } = usePopularTag();
+  const { useLimitPopularTag, usePopularTag, useLimitPopularTag7Day } =
+    useTag();
+  const limit7DayData = useLimitPopularTag7Day();
+  let tags; // 반환해줄 데이터
+  let isLimitLoading;
+  if (limit7DayData.data === undefined) {
+    let limitData = useLimitPopularTag();
+    tags = limitData.data;
+    isLimitLoading = limitData.isLoading;
+  } else {
+    tags = limit7DayData.data;
+  }
 
-  const tags = [
-    { tagId: 1, tagName: '직장인' },
-    { tagId: 2, tagName: '공대생' },
-    { tagId: 3, tagName: '취준생' },
-    { tagId: 4, tagName: '고민' },
-  ];
-  if (false) return <LottieLoading width={50} height={30} />;
+  // const tags = [
+  //   { tagId: 1, tagName: '직장인' },
+  //   { tagId: 2, tagName: '공대생' },
+  //   { tagId: 3, tagName: '취준생' },
+  //   { tagId: 4, tagName: '고민' },
+  // ];
+  if (limit7DayData.isLoading || isLimitLoading)
+    //7일인기 데이터 로딩 || 전체인기 데이터 로딩
+    return <LottieLoading width={50} height={30} />;
   return (
     <Container>
       <Text>인기태그</Text>

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -5,6 +5,7 @@ import { useQuery } from 'react-query';
 const useTag = () => {
   const popularTagKey = `popular-tag-list`;
   const tagListKey = `tag-list`;
+  const sevenDayPopularTagKey = `seven-day-popular-tag-list`;
 
   const usePopularTag = () => {
     return useQuery<Array<Tag>>(popularTagKey, async () => {
@@ -13,9 +14,18 @@ const useTag = () => {
   };
 
   const useLimitPopularTag = () => {
-    return useQuery<Array<Tag>>(popularTagKey, async () => {
-      return await tag.getLimitPopularTags();
-    });
+    return useQuery<Array<Tag>>(
+      popularTagKey,
+      async () => {
+        return await tag.getLimitPopularTags();
+      },
+      {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        retry: false,
+      }
+    );
   };
 
   const useTagList = () => {
@@ -24,7 +34,27 @@ const useTag = () => {
     });
   };
 
-  return { usePopularTag, useTagList, useLimitPopularTag };
+  const useLimitPopularTag7Day = () => {
+    return useQuery<Array<Tag>>(
+      sevenDayPopularTagKey,
+      async () => {
+        return await tag.getLimitPopularTags7Days();
+      },
+      {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        retry: false,
+      }
+    );
+  };
+
+  return {
+    usePopularTag,
+    useTagList,
+    useLimitPopularTag,
+    useLimitPopularTag7Day,
+  };
 };
 
 export default useTag;

--- a/src/service/tag.ts
+++ b/src/service/tag.ts
@@ -15,10 +15,16 @@ const getTags = async () => {
   return data;
 };
 
+const getLimitPopularTags7Days = async () => {
+  const data = await requestAPI().get('/popularTags/limit/7Days');
+  return data;
+};
+
 const tagApiList = {
   getPopularTags,
   getLimitPopularTags,
   getTags,
+  getLimitPopularTags7Days,
 };
 
 export default tagApiList;

--- a/src/typings/Board.ts
+++ b/src/typings/Board.ts
@@ -34,5 +34,6 @@ export interface RequestBoard {
 export type Tag = {
   tagId: number;
   tagName: string;
+  count: number;
 };
 export type BoardImage = { fileNm: string; filePath: string; url?: string };


### PR DESCRIPTION
1.인기 태그 api 연동

안녕하세요
인기 태그 api 연동 작업중
로직 순서는
1.popularLimit7Day api의 data가 없을때
2.popularLimit api를 호출시킨다.
3.1번의 data가 있다면 해당 data를 tags
4.1번의 data가 없다면 2번을 동작할시 2번 data를 tags
이렇게 구성하려고 하였는데,
에러 핸들링이 잘안되고 있어서 계속 돌고돌다가 코드만 지저분해지고 잘풀리지 않아서
merge목적이 아닌 review를 요청드리고자 pr 올리게 되었습니다.
useQuery부분에서 바로 error핸들링해서
data를 주고싶은데 잘되지않아서
Tag.tsx 부분에서 api를 결국 따로따로 호출하게되었습니다.
어떻게 개선해 나가는게 좋을까요?