### PR TITLE
Feature/article: 아티클 디자인 변경

### DIFF
--- a/src/components/Atoms/Board/Thumbnail.tsx
+++ b/src/components/Atoms/Board/Thumbnail.tsx
@@ -4,31 +4,62 @@ import styled from 'styled-components';
 interface Props {
   thumbnail?: string | null;
   writerImageUrl?: string | null;
+  isHome?: boolean | null;
+  writer?: string | null;
+  tags?: Array<string>;
 }
-const Thumbnail = ({ thumbnail, writerImageUrl }: Props) => {
+const Thumbnail = ({
+  thumbnail,
+  writerImageUrl,
+  isHome,
+  writer,
+  tags,
+}: Props) => {
   return (
     <>
       {thumbnail && (
         <>
-        <Container thumbnail={thumbnail}>
-            <Image
-              thumbnail={thumbnail}
-              src={thumbnail}
-            />
-        </Container>
-        {/* padding 으로 인한 Container 분리 */}
-        <Container>
-          <Image
-            src={writerImageUrl || ''}
-          />
-        </Container>
+          <Container thumbnail={thumbnail}>
+            <Image thumbnail={thumbnail} src={thumbnail} isHome={isHome} />
+          </Container>
+          {/* padding 으로 인한 Container 분리 */}
+          <Container isHome={isHome}>
+            {isHome ? (
+              <>
+                <Image src={writerImageUrl || ''} />
+                <Division>
+                  <Author>{writer}</Author>
+                  <Tags>
+                    {tags?.map((tag, id) => (
+                      <Tags key={id}>#{tag}</Tags>
+                    ))}
+                  </Tags>
+                </Division>
+              </>
+            ) : (
+              <Image src={writerImageUrl || ''} />
+            )}
+          </Container>
         </>
       )}
+      {/* 사진이 있는 게시글과 사진이 없는 게시글을 나눔. */}
       {!thumbnail && (
-        <Container>
-          <Image
-            src={writerImageUrl || ''}
-          />
+        <Container isHome={isHome}>
+          {isHome ? (
+            <>
+              <Image src={writerImageUrl || ''} />
+              <Division>
+                <Author>{writer}</Author>
+                <Tags>
+                  {tags?.map((tag, id) => (
+                    <Tags key={id}>#{tag}</Tags>
+                  ))}
+                </Tags>
+              </Division>
+            </>
+          ) : (
+            <Image src={writerImageUrl || ''} />
+          )}
         </Container>
       )}
     </>
@@ -37,16 +68,44 @@ const Thumbnail = ({ thumbnail, writerImageUrl }: Props) => {
 
 export default Thumbnail;
 
-const Container = styled.div<{ thumbnail?: string | null }>`
+const Container = styled.div<{
+  thumbnail?: string | null;
+  isHome?: boolean | null;
+}>`
   width: 100%;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
-  padding: ${({ thumbnail }) => (!thumbnail && '4%')};
+  padding: ${({ thumbnail }) => !thumbnail && '4%'};
   padding-bottom: 0;
+  display: ${({ isHome }) => (isHome ? 'flex' : 'block')};
 `;
 
-const Image = styled.img<{ thumbnail?: string | null }>`
+const Image = styled.img<{
+  thumbnail?: string | null;
+  isHome?: boolean | null;
+}>`
   width: ${({ thumbnail }) => (thumbnail ? '100%' : '40px')};
-  height: ${({ thumbnail }) => (thumbnail ? '170px' : '40px')};
+  height: ${({ thumbnail, isHome }) =>
+    isHome && thumbnail ? '139px' : thumbnail ? '170px' : '40px'};
   border-radius: ${({ thumbnail }) => (thumbnail ? '10px 10px 0 0' : '10px')};
 `;
+
+const Author = styled.span`
+  font-weight: 400;
+  font-size: 14px;
+  color: ${({ theme }) => theme.colors.gray.gray400};
+  margin-left: 8px;
+`;
+
+const Tags = styled.div`
+  color: ${({ theme }) => theme.colors.primary.default};
+  font-weight: 400;
+  font-size: 14px;
+  margin-left: 8px;
+  &:first-child {
+    margin: 0;
+  }
+  display: flex;
+`;
+
+const Division = styled.div``;

--- a/src/components/Atoms/Board/Thumbnail.tsx
+++ b/src/components/Atoms/Board/Thumbnail.tsx
@@ -7,27 +7,46 @@ interface Props {
 }
 const Thumbnail = ({ thumbnail, writerImageUrl }: Props) => {
   return (
-    <Container thumbnail={thumbnail}>
-      {<Image thumbnail={thumbnail} src={thumbnail || writerImageUrl || ''} />}
-    </Container>
+    <>
+      {thumbnail && (
+        <>
+        <Container thumbnail={thumbnail}>
+            <Image
+              thumbnail={thumbnail}
+              src={thumbnail}
+            />
+        </Container>
+        {/* padding 으로 인한 Container 분리 */}
+        <Container>
+          <Image
+            src={writerImageUrl || ''}
+          />
+        </Container>
+        </>
+      )}
+      {!thumbnail && (
+        <Container>
+          <Image
+            src={writerImageUrl || ''}
+          />
+        </Container>
+      )}
+    </>
   );
 };
 
 export default Thumbnail;
 
 const Container = styled.div<{ thumbnail?: string | null }>`
-  display: flex;
   width: 100%;
-  height: ${({ thumbnail }) => thumbnail && '257px'};
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
-  padding: ${({ thumbnail }) => !thumbnail && '5%'};
+  padding: ${({ thumbnail }) => (!thumbnail && '4%')};
   padding-bottom: 0;
 `;
 
 const Image = styled.img<{ thumbnail?: string | null }>`
   width: ${({ thumbnail }) => (thumbnail ? '100%' : '40px')};
-  height: ${({ thumbnail }) => (thumbnail ? '100%' : '40px')};
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
+  height: ${({ thumbnail }) => (thumbnail ? '170px' : '40px')};
+  border-radius: ${({ thumbnail }) => (thumbnail ? '10px 10px 0 0' : '10px')};
 `;

--- a/src/components/Atoms/Board/Thumbnail.tsx
+++ b/src/components/Atoms/Board/Thumbnail.tsx
@@ -28,7 +28,7 @@ const Thumbnail = ({
               <>
                 <Image src={writerImageUrl || ''} />
                 <Division>
-                  <Author>{writer}</Author>
+                  <Author>by. {writer}</Author>
                   <Tags>
                     {tags?.map((tag, id) => (
                       <Tags key={id}>#{tag}</Tags>

--- a/src/components/Molecules/Board/Card.tsx
+++ b/src/components/Molecules/Board/Card.tsx
@@ -11,47 +11,77 @@ interface Props {
   category: number | null;
   search: string;
   isBookmark: boolean;
+  isHome?: boolean; // 아티클페이지인지 메인페이지인지 구별하는 Prop
 }
-const Card = ({ board, category, search, isBookmark }: Props) => {
-  return (
-    <Container>
-      <Link
-        to={`/community/board/${board.boardId}`}
-        style={{ width: '100%', textDecoration: 'none' }}
-      >
-        <Thumbnail
-          thumbnail={board.thumbnailUrl}
-          writerImageUrl={board.writerImageUrl}
-        />
-      </Link>
-      <CardContent
-        board={board}
-        category={category}
-        search={search}
-        isBookmark={isBookmark}
-      />
+const Card = ({ board, category, search, isBookmark, isHome }: Props) => {
+  console.log(board);
 
-      <Bottom>
-        <Author>by. {board.writer}</Author>
-        <Status
-          board={board}
-          category={category}
-          search={search}
-          isBookmark={isBookmark}
-        />
-      </Bottom>
-    </Container>
+  return (
+    <>
+      {isHome ? (
+        <Container isHome={true}>
+          <Link
+            to={`/community/board/${board.boardId}`}
+            style={{ width: '100%', textDecoration: 'none' }}
+          >
+            <Thumbnail
+              thumbnail={
+                'https://doitcommit.s3.ap-northeast-2.amazonaws.com/2022/07/24/99cef549-f0f3-41e9-94fc-d1f3770dfa01_MjA2NDkuNDAwODY5NDU2NDM2MTY1ODY0NjkwOTQzNg%3D.png'
+              }
+              writerImageUrl={board.writerImageUrl}
+              isHome={true}
+              writer={'사용자이름'}
+              tags={board.boardHashtagNameList}
+            />
+          </Link>
+          <CardContent
+            board={board}
+            category={category}
+            search={search}
+            isBookmark={isBookmark}
+            isHome={isHome}
+          />
+        </Container>
+      ) : (
+        <Container>
+          <Link
+            to={`/community/board/${board.boardId}`}
+            style={{ width: '100%', textDecoration: 'none' }}
+          >
+            <Thumbnail
+              thumbnail={board.thumbnailUrl}
+              writerImageUrl={board.writerImageUrl}
+            />
+          </Link>
+          <CardContent
+            board={board}
+            category={category}
+            search={search}
+            isBookmark={isBookmark}
+          />
+          <Bottom>
+            <Author>by. {board.writer}</Author>
+            <Status
+              board={board}
+              category={category}
+              search={search}
+              isBookmark={isBookmark}
+            />
+          </Bottom>
+        </Container>
+      )}
+    </>
   );
 };
 
 export default React.memo(Card);
 
-const Container = styled.div`
+const Container = styled.div<{ isHome?: boolean }>`
   display: flex;
   flex-direction: column;
   width: 386px;
   max-width: 386px;
-  height: 451px;
+  height: ${({ isHome }) => (isHome ? '330px' : '451px')};
   background-color: ${({ theme }) => theme.colors.gray.gray100};
   box-shadow: ${({ theme }) => theme.boxShadow};
   border-radius: 10px;

--- a/src/components/Molecules/Board/Card.tsx
+++ b/src/components/Molecules/Board/Card.tsx
@@ -1,6 +1,6 @@
 import CardContent from './CardContent';
 import Thumbnail from '@src/components/Atoms/Board/Thumbnail';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { IBoard } from '@src/typings/Board';
@@ -14,16 +14,28 @@ interface Props {
   isHome?: boolean; // 아티클페이지인지 메인페이지인지 구별하는 Prop
 }
 const Card = ({ board, category, search, isBookmark, isHome }: Props) => {
-  console.log(board);
+  const [isHover, setIsHover] = useState<boolean>(false);
+  const onToggle = useCallback((value) => {
+    setIsHover(value);
+  }, []);
 
   return (
     <>
       {isHome ? (
-        <Container isHome={true}>
+        <Container
+          isHome={true}
+          onMouseEnter={() => {
+            onToggle(true);
+          }}
+          onMouseLeave={() => {
+            onToggle(false);
+          }}
+        >
           <Link
             to={`/community/board/${board.boardId}`}
             style={{ width: '100%', textDecoration: 'none' }}
           >
+            {/* TODO: 22.07-31 썸네일, writer Props는 백엔드 수정 후 변경해준다.*/}
             <Thumbnail
               thumbnail={
                 'https://doitcommit.s3.ap-northeast-2.amazonaws.com/2022/07/24/99cef549-f0f3-41e9-94fc-d1f3770dfa01_MjA2NDkuNDAwODY5NDU2NDM2MTY1ODY0NjkwOTQzNg%3D.png'
@@ -40,10 +52,18 @@ const Card = ({ board, category, search, isBookmark, isHome }: Props) => {
             search={search}
             isBookmark={isBookmark}
             isHome={isHome}
+            isHover={isHover}
           />
         </Container>
       ) : (
-        <Container>
+        <Container
+          onMouseEnter={() => {
+            onToggle(true);
+          }}
+          onMouseLeave={() => {
+            onToggle(false);
+          }}
+        >
           <Link
             to={`/community/board/${board.boardId}`}
             style={{ width: '100%', textDecoration: 'none' }}
@@ -58,6 +78,7 @@ const Card = ({ board, category, search, isBookmark, isHome }: Props) => {
             category={category}
             search={search}
             isBookmark={isBookmark}
+            isHover={isHover}
           />
           <Bottom>
             <Author>by. {board.writer}</Author>

--- a/src/components/Molecules/Board/CardContent.tsx
+++ b/src/components/Molecules/Board/CardContent.tsx
@@ -14,6 +14,7 @@ interface Props {
   search: string;
   isBookmark: boolean;
   isHome?: boolean;
+  isHover: boolean;
 }
 const CardContent = ({
   board,
@@ -21,6 +22,7 @@ const CardContent = ({
   search,
   isBookmark,
   isHome,
+  isHover,
 }: Props) => {
   const theme = useTheme();
   const keyword = useRecoilValue(keywordState);
@@ -36,7 +38,6 @@ const CardContent = ({
   const onClickBookmark = useCallback(async () => {
     mutation.mutate(board);
   }, [mutation, board]);
-
   return (
     <Container>
       <Top>
@@ -56,7 +57,12 @@ const CardContent = ({
           <BsBookmarkFill
             onClick={onClickBookmark}
             color={theme.colors.primary.default}
-            style={{ marginLeft: 'auto', cursor: 'pointer' }}
+            style={{
+              marginLeft: 'auto',
+              cursor: 'pointer',
+              transition: 'all 0.7s',
+              opacity: isHover ? 1 : 0,
+            }}
           />
         ) : (
           <BsBookmark
@@ -65,6 +71,8 @@ const CardContent = ({
               marginLeft: 'auto',
               cursor: 'pointer',
               color: theme.colors.gray.gray400,
+              transition: 'all 0.7s',
+              opacity: isHover ? 1 : 0,
             }}
           />
         )}

--- a/src/components/Molecules/Board/CardContent.tsx
+++ b/src/components/Molecules/Board/CardContent.tsx
@@ -33,9 +33,18 @@ const CardContent = ({ board, category, search, isBookmark }: Props) => {
   return (
     <Container>
       <Top>
-        {board.boardHashtagNameList?.map((tag, id) => (
-          <Tags key={id}>#{tag}</Tags>
-        ))}
+        <Title>
+          <Highlighter
+            highlightStyle={{
+              color: theme.colors.primary.default,
+            }}
+            highlightTag="strong"
+            searchWords={keyword}
+            autoEscape={true}
+            textToHighlight={board.boardTitle}
+          />
+        </Title>
+
         {board.myBookmark ? (
           <BsBookmarkFill
             onClick={onClickBookmark}
@@ -58,17 +67,11 @@ const CardContent = ({ board, category, search, isBookmark }: Props) => {
         style={{ width: '100%', height: '100%', textDecoration: 'none' }}
       >
         <Middle>
-          <Title>
-            <Highlighter
-              highlightStyle={{
-                color: theme.colors.primary.default,
-              }}
-              highlightTag="strong"
-              searchWords={keyword}
-              autoEscape={true}
-              textToHighlight={board.boardTitle}
-            />
-          </Title>
+          <TagsContainer>
+          {board.boardHashtagNameList?.map((tag, id) => (
+            <Tags key={id}>#{tag}</Tags>
+            ))}
+            </TagsContainer>
           <Content>
             <Highlighter
               highlightStyle={{
@@ -104,10 +107,16 @@ const Container = styled.div`
   border-bottom-right-radius: 10px;
   gap: 10px;
 `;
+const TagsContainer = styled.div``;
+// 빈 div역할
 const Tags = styled.span`
-  color: ${({ theme }) => theme.colors.gray.gray400};
+  color: ${({ theme }) => theme.colors.primary.default};
   font-weight: 400;
   font-size: 14px;
+  margin-left: 8px;
+  &:first-child {
+    margin: 0;
+  }
 `;
 
 const Title = styled.p`

--- a/src/components/Molecules/Board/CardContent.tsx
+++ b/src/components/Molecules/Board/CardContent.tsx
@@ -13,8 +13,15 @@ interface Props {
   category: number | null;
   search: string;
   isBookmark: boolean;
+  isHome?: boolean;
 }
-const CardContent = ({ board, category, search, isBookmark }: Props) => {
+const CardContent = ({
+  board,
+  category,
+  search,
+  isBookmark,
+  isHome,
+}: Props) => {
   const theme = useTheme();
   const keyword = useRecoilValue(keywordState);
   const mutation = useBoardListMutation(
@@ -67,11 +74,15 @@ const CardContent = ({ board, category, search, isBookmark }: Props) => {
         style={{ width: '100%', height: '100%', textDecoration: 'none' }}
       >
         <Middle>
-          <TagsContainer>
-          {board.boardHashtagNameList?.map((tag, id) => (
-            <Tags key={id}>#{tag}</Tags>
-            ))}
-            </TagsContainer>
+          <>
+            {isHome ? null : (
+              <TagsContainer>
+                {board.boardHashtagNameList?.map((tag, id) => (
+                  <Tags key={id}>#{tag}</Tags>
+                ))}
+              </TagsContainer>
+            )}
+          </>
           <Content>
             <Highlighter
               highlightStyle={{

--- a/src/components/Molecules/Todo/TodoBox.tsx
+++ b/src/components/Molecules/Todo/TodoBox.tsx
@@ -61,7 +61,7 @@ const TodoBox = ({ todo, onRefetch, isEmpty }: TodoBoxProps) => {
         onToggle(false);
       }}
     >
-      <BookmarkIcon isHover={isHover} />
+      {/* <BookmarkIcon isHover={isHover} /> */}
       {todo && (
         <Container>
           {!isEmpty && (

--- a/src/components/Organisms/Home/Community.tsx
+++ b/src/components/Organisms/Home/Community.tsx
@@ -1,19 +1,16 @@
 import CommunityBox from '@src/components/Molecules/Community/CommunityBox';
 import ContentBox from '@src/components/Molecules/ContentBox';
-import { useUser } from '@src/hooks/useAuthentication';
 import { useMainPageBoard } from '@src/hooks/useBoards';
 import React from 'react';
 import styled from 'styled-components';
 const Community = () => {
-  const { data: MainBoards } = useMainPageBoard();
-  const { data: user } = useUser();
   return (
     <ContentBox title="체크 두잇" requiredHeader>
-      {MainBoards &&
+      {/* TODO : 투두 리스트 기획 후 이곳에 */}
+      {/* {MainBoards &&
         MainBoards.map((board) => (
           <CommunityBox key={board.boardId} item={board} />
-        ))}
-      {/* <EmptyText>{user ? '비어있습니다.' : '로그인이 필요합니다.'}</EmptyText> */}
+        ))} */}
     </ContentBox>
   );
 };
@@ -22,7 +19,6 @@ const EmptyText = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-
   height: 300px;
   color: ${({ theme }) => theme.colors.gray.gray500};
   font-weight: 500;

--- a/src/components/Organisms/Home/MainBoard.tsx
+++ b/src/components/Organisms/Home/MainBoard.tsx
@@ -6,8 +6,6 @@ import React from 'react';
 import styled, { useTheme } from 'styled-components';
 const MainBoard = () => {
   const { data: MainBoards } = useMainPageBoard();
-  console.log(MainBoards);
-
   return (
     <ContentBox title={'📘 최신 아티클'} requiredHeader to={'/community'}>
       <Container>

--- a/src/components/Organisms/Home/MainBoard.tsx
+++ b/src/components/Organisms/Home/MainBoard.tsx
@@ -1,0 +1,41 @@
+import Card from '@src/components/Molecules/Board/Card';
+import ContentBox from '@src/components/Molecules/ContentBox';
+import { useMainPageBoard } from '@src/hooks/useBoards';
+import { IBoard } from '@src/typings/Board';
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+const MainBoard = () => {
+  const { data: MainBoards } = useMainPageBoard();
+  console.log(MainBoards);
+
+  return (
+    <ContentBox title={'📘 최신 아티클'} requiredHeader to={'/community'}>
+      <Container>
+        {MainBoards?.map((b: IBoard, i: number) => (
+          <Card
+            board={b}
+            key={i}
+            category={null}
+            search={''}
+            isBookmark={false}
+            isHome={true}
+          />
+        ))}
+      </Container>
+    </ContentBox>
+  );
+};
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, max-content));
+  @media (min-width: 1920px) {
+    grid-template-columns: repeat(2, minmax(400px, max-content));
+  }
+  justify-content: center;
+  row-gap: 30px;
+  column-gap: 30px;
+  width: 100%;
+  height: 100%;
+`;
+export default MainBoard;

--- a/src/hooks/useBoards.ts
+++ b/src/hooks/useBoards.ts
@@ -163,15 +163,7 @@ export const useSingleBoardMutation = (
 };
 
 export const useMainPageBoard = () => {
-  const { data: user } = useUser();
-
-  return useQuery<Array<IBoard>>(
-    'main-board',
-    async () => {
-      return await board.getMainPageBoard();
-    },
-    {
-      enabled: user !== null && user !== undefined,
-    }
-  );
+  return useQuery<Array<IBoard>>('main-board', async () => {
+    return await board.getMainPageBoard();
+  });
 };

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,6 +8,7 @@ import AdBanner from '@src/components/Organisms/Home/AdBanner';
 import { devices } from '@src/utils/theme';
 import Skeleton from '@src/components/Molecules/LoadingSkeleton';
 import ThemeButton from '@src/components/Atoms/ThemeButton';
+import MainBoard from '@src/components/Organisms/Home/MainBoard';
 
 const Home = () => {
   return (
@@ -31,7 +32,8 @@ const Home = () => {
         </Column>
         <Row>
           <Skeleton.Suspense>
-            <HomeTodoList />
+            {/* <HomeTodoList /> */}
+            <MainBoard />
             {/* 최신 아티클 4개 들어갈 자리 */}
           </Skeleton.Suspense>
         </Row>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -32,6 +32,7 @@ const Home = () => {
         <Row>
           <Skeleton.Suspense>
             <HomeTodoList />
+            {/* 최신 아티클 4개 들어갈 자리 */}
           </Skeleton.Suspense>
         </Row>
       </Container>


### PR DESCRIPTION
1. 아티클 페이지 새로운 디자인에 맞게 수정
2. 홈 최신 아티클 /board/main/list api 적용
3. 아티클 hover시 bookmark 노출 애니메이션 적용
[
![스크린샷 2022-07-31 오전 12 27 01](https://user-images.githubusercontent.com/49021925/182011923-2d863fd0-0bdd-4b16-b505-4c7e2f1de0c5.png)
](url)

다만 이번 PR에서는 card 컴포넌트와 Thumnail 컴포넌트 cardContent컴포넌트가 변경된 부분이 많이 있습니다.
게다가 홈의 아티클과 아티클페이지의 아티클의 디자인 형식이 조금 달랐는데, 웬만해서 이미 있던 컴포넌트를 재사용하고싶어서 
isHome prop으로 조건부 랜더링을 많이 적용 시켰습니다. 그러다보니 컴포넌트를 복잡하게 만든것같기도합니다..
혹시나 문제될 부분있으면 말씀해주시면 감사하겠습니다!