### PR TITLE
FIX: 대댓글 카운트 및 더 보기 수정

### DIFF
--- a/src/components/Atoms/ShowMoreText.tsx
+++ b/src/components/Atoms/ShowMoreText.tsx
@@ -1,0 +1,42 @@
+import ExpandIconSVG from '@src/assets/expand_comment.svg';
+import React from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  onClick: () => void;
+  length?: number;
+};
+
+const ShowMoreText = ({ length, onClick }: Props) => {
+  return (
+    <Container onClick={onClick}>
+      <LengthText>{length || 0}개의 댓글 더 보기</LengthText>
+      <ExpandIcon />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-basis: content;
+  flex-direction: row;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 1.75rem;
+`;
+
+const LengthText = styled.span`
+  color: ${({ theme }) => theme.colors.primary.default};
+  font-weight: 400;
+  font-size: 16px;
+
+  cursor: pointer;
+`;
+
+const ExpandIcon = styled(ExpandIconSVG)`
+  path {
+    fill: ${({ theme }) => theme.colors.primary.default};
+  }
+`;
+
+export default React.memo(ShowMoreText);

--- a/src/components/Molecules/Board/BoardContent.tsx
+++ b/src/components/Molecules/Board/BoardContent.tsx
@@ -1,12 +1,12 @@
 import { IBoard } from '@src/typings/Board';
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import CommentBox from './CommentBox';
 import CommentEditor from './CommentEditor';
 import useComments from '@src/hooks/useComments';
 import { IComment, ICommentRes } from '@src/typings/Comment';
-import ExpandIconSVG from '@src/assets/expand_comment.svg';
 import CommentIconSVG from '@src/assets/comment.svg';
+import ShowMoreText from '@src/components/Atoms/ShowMoreText';
 
 interface Props {
   boardData: IBoard;
@@ -16,27 +16,29 @@ const BoardContent = ({ boardData }: Props) => {
     boardData.boardId!
   );
 
-  const getComputedExtraPage = (
-    page: {
-      commentsData: ICommentRes;
-      nextPage: number;
-    }[]
-  ) => {
-    if (page[0].commentsData.commentCount >= 5 * (page.length + 1)) {
-      return 5;
-    }
-    return page[0].commentsData.commentCount % 5;
-  };
+  const getComputedExtraPage = useCallback(
+    (
+      page: {
+        commentsData: ICommentRes;
+        nextPage: number;
+      }[]
+    ) => {
+      if (page[0].commentsData.commentCount >= 3 * (page.length + 1)) {
+        return 3;
+      }
+      return page[0].commentsData.commentCount % 3;
+    },
+    []
+  );
 
   return (
     <Container>
       <Content>
-        <div dangerouslySetInnerHTML={{ __html: boardData.boardContent }}></div>
+        <div dangerouslySetInnerHTML={{ __html: boardData.boardContent }} />
       </Content>
-      {/* 댓글이 5개가 넘었을 경우 더보기 */}
       <CommentCountWrapper>
         <CommentIconSVG />
-        <span>{comments?.pages[0].commentsData.commentCount}</span>
+        <TotalText>{comments?.pages[0].commentsData.commentCount}</TotalText>
       </CommentCountWrapper>
 
       {!isLoading &&
@@ -54,14 +56,10 @@ const BoardContent = ({ boardData }: Props) => {
           ))
         )}
       {hasNextPage && (
-        <LoadMoreWrapper>
-          <div onClick={() => fetchNextPage()}>
-            <span>
-              {getComputedExtraPage(comments?.pages!)}개의 댓글 더 보기
-            </span>
-            <ExpandIconSVG />
-          </div>
-        </LoadMoreWrapper>
+        <ShowMoreText
+          onClick={() => fetchNextPage()}
+          length={getComputedExtraPage(comments?.pages!)}
+        />
       )}
       {!isLoading && (
         <CommentEditor
@@ -113,40 +111,15 @@ const Content = styled.div`
   }
 `;
 
-const LoadMoreWrapper = styled.div`
-  display: flex;
-  flex-basis: content;
-  flex-direction: row;
-  justify-content: center;
-  gap: 4px;
-  margin-bottom: 1.75rem;
-
-  & > div {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    & > span {
-      color: ${({ theme }) => theme.colors.primary.default};
-      font-weight: 500;
-      font-size: 20px;
-    }
-
-    & > svg {
-      & > path {
-        fill: ${({ theme }) => theme.colors.primary.default};
-      }
-    }
-  }
-`;
 const CommentCountWrapper = styled.div`
   display: flex;
   flex-direction: row;
   margin-bottom: 15px;
   gap: 5px;
+`;
 
-  & > span {
-    color: ${({ theme }) => theme.colors.primary.default};
-    font-weight: 400;
-    font-size: 16px;
-  }
+const TotalText = styled.span`
+  color: ${({ theme }) => theme.colors.primary.default};
+  font-weight: 400;
+  font-size: 16px;
 `;


### PR DESCRIPTION
1. 대댓글 더 보기 추가하였습니다.

![image](https://user-images.githubusercontent.com/38070150/185789008-d4595cf4-b19d-4ab9-8833-ac9228aa5350.png)

2. 댓글 더 보기 페이지 수 3개로 바꿨습니다. 

- 특정 게시판에 댓글 총 개수가 맞지 않는데 DB에 대댓글 수정 전에 잘못된 데이터가 들어가 있어서 그렇습니다.