### PR TITLE
썸네일 이미지 개선

### DIFF
--- a/src/components/Atoms/Board/Thumbnail.tsx
+++ b/src/components/Atoms/Board/Thumbnail.tsx
@@ -88,6 +88,8 @@ const Image = styled.img<{
   height: ${({ thumbnail, isHome }) =>
     isHome && thumbnail ? '139px' : thumbnail ? '170px' : '40px'};
   border-radius: ${({ thumbnail }) => (thumbnail ? '10px 10px 0 0' : '10px')};
+
+  object-fit: cover;
 `;
 
 const Author = styled.span`


### PR DESCRIPTION
준민님이 issue에서 썸네일 이미지 관련  조언을 주셔서 object-fit cover로 적용시켰습니다.
@junmin-Chang 

### 적용 전
![before](https://user-images.githubusercontent.com/38070150/187665664-c410b343-d7b6-4889-8182-f008344c0f39.PNG)

### 적용 후
![after](https://user-images.githubusercontent.com/38070150/187665667-9a0131bf-aaf7-4374-958a-adc9817d8c77.PNG)
