### PR TITLE
fix : 검색결과가 존재하지 않을때 로티에니메이션 정렬 수정 및 검색 시 필터링옵션에 맞게 조건부 랜더링 추가

### DIFF
--- a/src/components/Atoms/LottieAnimation.tsx
+++ b/src/components/Atoms/LottieAnimation.tsx
@@ -50,6 +50,7 @@ const Container = styled.div<{ width?: number; height?: number }>`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin: 0 auto;
 `;
 
 const EmptyAnimationDiv = styled.div``;
@@ -57,7 +58,7 @@ const EmptyAnimationDiv = styled.div``;
 const EmptyText = styled.div`
   color: ${({ theme }) => theme.colors.warning};
   font-weight: 500;
-  font-size: 16px;
+  font-size: 15px;
 `;
 
 export default LottieAnimation;

--- a/src/components/Organisms/Board/Articles.tsx
+++ b/src/components/Organisms/Board/Articles.tsx
@@ -5,6 +5,7 @@ import PopularSlider from '@src/components/Molecules/Board/PopularSlider';
 import MainArticle from './MainArticle';
 import { useRecoilValue } from 'recoil';
 import myBoardAtom from '@src/recoil/atom/myBoard';
+import { searchAtom } from '@src/recoil/atom/search';
 
 type Props = {
   search?: string;
@@ -14,6 +15,7 @@ type Props = {
 const Articles = (props: Props) => {
   const theme = useTheme();
   const isShowBookmarkList = useRecoilValue(myBoardAtom); // 북마크조회가 아닐때는 기본 메인 아티클을 표시한다.
+  const isSearch = useRecoilValue(searchAtom);
   return (
     <React.Fragment>
       {(isShowBookmarkList.bookmark || isShowBookmarkList.history) && (
@@ -21,14 +23,18 @@ const Articles = (props: Props) => {
       )}
       {!isShowBookmarkList.bookmark && !isShowBookmarkList.history && (
         <>
-          <DIText
-            fontColor={theme.colors.gray.gray950}
-            fontWeight={700}
-            fontSize={24}
-          >
-            🔥 가장 인기있는 아티클
-          </DIText>
-          <PopularSlider />
+          {!isSearch.complete && (
+            <>
+              <DIText
+                fontColor={theme.colors.gray.gray950}
+                fontWeight={700}
+                fontSize={24}
+              >
+                🔥 가장 인기있는 아티클
+              </DIText>
+              <PopularSlider />
+            </>
+          )}
           <MainArticle {...props} />
         </>
       )}


### PR DESCRIPTION
기존 이미지는 첨부하지 못하였는데 검색창에서 검색된 아티클이 없을 시,
레이아웃이 왼쪽에 정렬되었고, 가장인기있는 아티클 컴포넌트가 보여져서 이부분을 처리하였습니다.
또한 검색결과가 있고, 분야 필터링을 해서 아티클이없을 시 emptyLottie 메세지를 변경하였습니다.
![사진1](https://user-images.githubusercontent.com/49021925/196495406-c817e786-014f-4eb6-8bce-5be61c02c960.png)
![사진2](https://user-images.githubusercontent.com/49021925/196495440-1060fe5c-a22f-463e-bc28-d56ec6baa55d.png)
