### PR TITLE
AxiosInstance 에러 핸들링 처리.

### DIFF
--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -20,6 +20,10 @@ const handleResponse = (response: AxiosResponse) => {
       error: 'bad Response',
     };
   }
+
+  if (response.status === 400) {
+    return null;
+  }
   return response.data;
 };
 
@@ -50,6 +54,9 @@ export const requestAPI = () => {
         data: bodyJson,
         headers: {
           'Content-Type': contentType ?? 'application/json',
+        },
+        validateStatus: () => {
+          return true;
         },
       })
         .then(handleResponse)


### PR DESCRIPTION
API request시에 에러 발생 시 전부 then을 타고 handleResponse으로 처리되서 리턴 값이 제대로 표시가 안되는 경우가 있는데 테스트해보니 에러값도 이 경우로 필터되서 response가 타입에 맞지 않게 처리 되고 있었습니다.

AxiosInstance내에 validateStatus가 있는데 Promise reject나 resolve처리를 http status 코드로 처리하는데 전부 true로 반환해서 처리해 저희가 만든 handleResponse에서 error핸들링을 처리할 수 있도록 했습니다.

